### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_script:
 - yarn install
 - yarn run build
 node_js:
-- "9"
+- node
 deploy:
   app: boopjs
   provider: heroku

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_script:
 - yarn install
 - yarn run build
 node_js:
-- node
+- "9"
 deploy:
   app: boopjs
   provider: heroku

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
   "dependencies": {
     "express": "^4.16.2"
   },
-  "engines": {
-    "node": "9.0.0"
-  },
   "devDependencies": {
     "buble-loader": "^0.4.1",
     "cannon": "^0.6.2",


### PR DESCRIPTION
Removed node version specification in package.json and .travis.yml.

Sorta hacky, the server logic shouldn't be cutting edge. Travis is now able to build.